### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [ :new, :create, :edit, :update ]
-  before_action :set_item, only: [ :show, :edit, :update ]
-  before_action :move_to_index, only:  [ :edit, :update ]
+  before_action :authenticate_user!, only: [ :new, :create, :edit, :update, :destroy ]
+  before_action :set_item, only: [ :show, :edit, :update, :destroy ]
+  before_action :move_to_index, only:  [ :edit, :update, :destroy ]
   def index
     @items =Item.order("created_at DESC")
   end
@@ -29,6 +29,11 @@ class ItemsController < ApplicationController
     else
       render :edit
     end
+  end
+
+  def destroy
+    @item.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
     <% if user_signed_in? && current_user.id == @item.user_id %>
       <%= link_to "商品の編集",  edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
       <p class="or-text">or</p>
-      <%= link_to "削除", "#" , method: :delete, class:"item-destroy" %>
+      <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
     <% elsif user_signed_in? %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
       <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [ :index, :new, :create, :show, :edit, :update ]
+  resources :items
 end


### PR DESCRIPTION
# What
ルーティング　destroyアクション定義とbefore＿actionへの追加　ボタンのリンクの作成
# Why
商品削除機能の実装のため

ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる
https://gyazo.com/9d18cc67f7cb6312332891bbb8b08540
